### PR TITLE
Capitalized 'name'

### DIFF
--- a/about.json
+++ b/about.json
@@ -1,5 +1,5 @@
 {
-  "name": "Header submenus",
+  "name": "Header Submenus",
   "about_url": "https://meta.discourse.org/t/",
   "license_url": "https://github.com/hnb-ku/discourse-header-submenus/blob/master/LICENSE",
   "component": true


### PR DESCRIPTION
It was 'Header submenus' rather than 'Header Submenus'; I think this may affect whether it shows as installed…when I'm on my forum's '/admin/customize/themes' page and click 'install' I don't see this one listed as 'installed' possibly b/c of the slight name mismatch.