### PR TITLE
Replaces settings lists by textareas

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -36,8 +36,8 @@ const { iconHTML } = require("discourse-common/lib/icon-library"),
     ? iconHTML("caret-down", { class: "header-menu-caret" })
     : "";
 
-let sec = $.map(settings.Menu_items.split("|"), $.trim),
-  seg = $.map(settings.Submenu_items.split("|"), $.trim),
+let sec = $.map(settings.Menu_items.trim().split(/\n|\|/), $.trim),
+  seg = $.map(settings.Submenu_items.trim().split(/\n|\|/), $.trim),
   rawMain = "",
   mainUl = "";
 

--- a/settings.yml
+++ b/settings.yml
@@ -1,17 +1,49 @@
 Menu_items:
-  type: list
-  default: "Design, magic, Get inspired!, vdm|Code, far-keyboard, Learn new things!, vdm|Business, far-money-bill-alt, Start a new career!, vdm|Shop, shopping-cart, Buy cool stuff!, vdo|More, none, Even more cool things!, vdo"
+  type: string
+  textarea: true
+  default: |
+    Design, magic, Get inspired!, vdm
+    Code, far-keyboard, Learn new things!, vdm
+    Business, far-money-bill-alt, Start a new career!, vdm
+    Shop, shopping-cart, Buy cool stuff!, vdo
+    More, none, Even more cool things!, vdo
   description:
     en: "Add menu items. One item per line in this order: Text, icon, title, view.<br><b>Text:</b> what appears on the menu.<br><b>Icon:</b> the icon displayed next to the item. If you do not want to use an icon, use `none`<br><b>Title:</b> the text that appears when the item is hovered.<br><b>View:</b> Choose what devices the item appears on. `vdm` appears on both desktop and mobile, `vdo` appears on desktops only, `vmo` appears on mobiles only. Due to lack of space, it is reccomended to not add more than 3-4 items on mobile."
 Submenu_items:
-  type: list
-  default: "Design, Galleries, th, #, blank, Cool galleries for you to look at.|Design, Design process, far-lightbulb, #, blank, Learn the basics.|Design, Blog design, columns, #, blank, What makes for a great blog?|Design, divider|Design, Freebies, gift, #, blank, Everyone likes freebies!|Design, Photoshop tutorials, book, #, blank, Photoshop for beginners.|Design, Design trends, far-chart-bar, #, blank, Stay on top of the current trends! |Code, Wordpress, wordpress, #, blank, Wordpress code examples|Code, Tools, wrench, #, blank, Tools that will make your life easier!|Code, Tutorials, fab-leanpub, #, blank, Just starting out? We'll guide you through the basics|Business, Blogging, none, #, blank, Why not start a blog?|Business, Social media, none, #, blank, Learn how to leverage Social media and make it work for your business |Business, Make money, none, #, blank, Everyone like to be paid!|Business, Marketing, none, #, blank, No business will survive without customers...Here's how to get'em!|Shop, Vectors, none, #, blank,|Shop, Textures, none, #, blank,|Shop, Brushes, none, #, blank,|Shop, divider|Shop, UI kits, none, #, blank,|Shop, Templates , none, #, blank,|Shop, PSDs, none, #, blank,|More, About us, none, /about, self, Meet the gang!|More, Contact us, none, #, blank, Let's get in touch|More, Terms of Service, none, /tos, self, |More, Privacy policy, none, /privacy, self"
+  type: string
+  textarea: true
+  default: |
+    Design, Galleries, far-images, #, blank, Cool galleries for you to look at.
+    Design, Design process, far-lightbulb, #, blank, Learn the basics.
+    Design, Blog design, columns, #, blank, What makes for a great blog?
+    Design, divider
+    Design, Freebies, gift, #, blank, Everyone likes freebies!
+    Design, Photoshop tutorials, book, #, blank, Photoshop for beginners.
+    Design, Design trends, far-chart-bar, #, blank, Stay on top of the current trends! 
+    Code, Wordpress, wordpress, #, blank, Wordpress code examples
+    Code, Tools, wrench, #, blank, Tools that will make your life easier!
+    Code, Tutorials, fab-leanpub, #, blank, Just starting out? We'll guide you through the basics
+    Business, Blogging, none, #, blank, Why not start a blog?
+    Business, Social media, none, #, blank, Learn how to leverage Social media and make it work for your business 
+    Business, Make money, none, #, blank, Everyone like to be paid!
+    Business, Marketing, none, #, blank, No business will survive without customers...Here's how to get'em!
+    Shop, Vectors, none, #, blank
+    Shop, Textures, none, #, blank
+    Shop, Brushes, none, #, blank
+    Shop, divider
+    Shop, UI kits, none, #, blank
+    Shop, Templates , none, #, blank
+    Shop, PSDs, none, #, blank
+    More, About us, none, /about, self, Meet the gang!
+    More, Contact us, none, #, blank, Let's get in touch
+    More, Terms of Service, none, /tos, self
+    More, Privacy policy, none, /privacy, self
   description:
     en: "Add submenu items. One item per line in this order: Parent, text, icon, URL, target, title.<br><b>Parent:</b> the name of the parent menu item which this submenu item show under. Use the `text` value from the list above<br><b>Text:</b> the text that shows for this submenu item.<br><b>Icon:</b> the icon for this submenu item, use `none` if no icon is needed<br><b>URL:</b> the path this menu item links to. You can use relative paths as well.<br><b>Target:</b> Choose whether this item will open in a new tab or in the same tab. Use `blank` to open the link in a new tab, or use `self` to open it in the same tab.<br><b>Title:</b> the text that shows when the item is hovered.<br><b>Dividers:</b> You can also add dividers between submenu items. To add a divider user `parent, divider`"
 Svg_icons:
   type: "list"
   list_type: "compact"
-  default: "fa-magic|far-keyboard|far-money-bill-alt|fa-shopping-cart|far-lightbulb|fa-columns|fa-gift|fa-book|far-chart-bar|fab-wordpress|fa-wrench|fab-leanpub"
+  default: "fa-magic|far-keyboard|far-money-bill-alt|fa-shopping-cart|far-lightbulb|fa-columns|fa-gift|fa-book|far-chart-bar|fab-wordpress|fa-wrench|fab-leanpub|far-images"
   description:
     en: "Include FontAwesome icon classes for each icon used in the lists above."
 Fixed_mode:


### PR DESCRIPTION
Current list elements for menu and submenus aren't practical when you want to modify or reorder them. I was asked by a client to replace them with textareas.

A problem with my modification is that I modified two settings types, so previous values will be overwritten if a user updates the theme component, reinitializing their menu and submenu elements to default examples ones. It's a bit sad since the current string values with pipes as separators (from a list type setting) would be correctly be parsed and split by the theme component anyway. 🤷🏽‍♂️