### PR TITLE
UX: update fixed styling for sidebar & chat

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -1,8 +1,8 @@
 $item-height: 40px;
 
 @if $Fixed_mode == "true" {
-  .top-menu {
-    position: fixed;
+  .header-submenus {
+    position: sticky;
     top: 0;
     z-index: z("header") + 1;
   }
@@ -13,6 +13,28 @@ $item-height: 40px;
 
   #main-outlet {
     padding-top: calc(1.8em + #{$item-height});
+  }
+
+  // need to include the menu height in the header offset
+  // then update the header offset where used in core for sidebar and chat
+  :root {
+    --header-offset-with-submenu: calc(
+      var(--header-offset, 0px) + #{$item-height}
+    );
+  }
+
+  .sidebar-wrapper {
+    top: var(--header-offset-with-submenu);
+    height: calc(100vh - var(--header-offset-with-submenu, 0px));
+  }
+
+  html.has-full-page-chat body #main-outlet {
+    max-height: calc(
+      var(--chat-vh, 1vh) *
+        100 -
+        var(--header-offset-with-submenu, 0px) -
+        var(--composer-height, 0px)
+    );
   }
 }
 


### PR DESCRIPTION
The `fixed_mode` setting needs updated styling to account for the sticky Discourse header (formerly fixed). 

This also includes updating the sidebar height and top position, and chat's max-height to account for the custom header. 

Before (the top of the sidebar and chat are obscured):
![Screenshot 2023-04-07 at 4 20 57 PM](https://user-images.githubusercontent.com/1681963/230673926-dce4a4ed-1642-4a17-9eb4-b385a4f91624.png)


After:
![Screenshot 2023-04-07 at 4 21 16 PM](https://user-images.githubusercontent.com/1681963/230673968-f9da752e-f08f-4eaf-8cff-36dc8b3e4cc4.png)


