### PR TITLE
UX: adjust header offset for timeline and avatars

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -24,6 +24,16 @@ $item-height: 40px;
     height: calc(100vh - var(--header-offset-with-submenu, 0px));
   }
 
+  .topic-post.sticky-avatar .topic-avatar {
+    top: calc(var(--header-offset-with-submenu) - 0.25em);
+  }
+
+  @media screen and (min-width: 925px) {
+    .container.posts .topic-navigation {
+      top: calc(var(--header-offset-with-submenu) + 2em);
+    }
+  }
+
   html.has-full-page-chat body #main-outlet {
     max-height: calc(
       var(--chat-vh, 1vh) *


### PR DESCRIPTION
This fixes an issue where the sticky position header overlaps the timeline and sticky avatars in "fixed" mode. 

<img width="776" alt="Screenshot 2023-04-11 at 12 21 28 PM" src="https://user-images.githubusercontent.com/1681963/231226582-776de78a-96ef-4802-bce1-9185e03127d9.png">
